### PR TITLE
Fix handling of print() functions

### DIFF
--- a/baseplate_py_upgrader/refactor.py
+++ b/baseplate_py_upgrader/refactor.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 def refactor_python_files(root: Path, fix_package: str) -> None:
     fixers = get_fixers_from_package(fix_package)
+    options = {"print_function": True}
     refactoring_tool = StdoutRefactoringTool(
-        fixers=fixers, options={}, explicit=[], nobackups=True, show_diffs=False
+        fixers=fixers, options=options, explicit=[], nobackups=True, show_diffs=False,
     )
     refactoring_tool.refactor([root], write=True)


### PR DESCRIPTION
The refactoring tooling uses lib2to3 who, shockingly obviously in
retrospect, is designed for handling Python 2 input text. Unless we
enable the print_function flag on the refactorer, it treats them the old
way and generates a syntax error on those constructs in nice modern
source. Cool.