### PR TITLE
Make sure reddit-v2-events new enough for thrift-unofficial

### DIFF
--- a/baseplate_py_upgrader/fixes/v2_0/__init__.py
+++ b/baseplate_py_upgrader/fixes/v2_0/__init__.py
@@ -194,6 +194,7 @@ def update(
     package_repo.ensure(
         requirements_file, "python-json-logger>=2.0,<3.0", required=True
     )
+    package_repo.ensure(requirements_file, "reddit-v2-events>=1.21.4")
 
     if "baseplate.lib.experiments" in RENAMES.names_seen:
         package_repo.ensure(


### PR DESCRIPTION
Before this version, reddit-v2-events depended on "thrift" directly. As
of Baseplate.py v2.0 we depend on thrift-unofficial since we're ahead of
the official releases on PyPI. The two packages overwrite eachother so
this conflicting requirement was breaking usage of Thrift in
Baseplate.py. This ensures projects are using a sufficiently new
reddit-v2-events to not get the conflicting installation.