### PR TITLE
Add support for upgrading to 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 This tool will help you make the changes necessary to upgrade your Baseplate.py
 service from one version to another.
 
-Install the upgrader on your development machine (outside any VMs, since this
-will be editing source code):
+The easiest way to use this tool is through `pipx` (`brew install pipx` on
+macOS):
 
-    pip3.7 install git+https://github.com/reddit/baseplate.py-upgrader
+    pipx run --spec git+https://github.com/reddit/baseplate.py-upgrader baseplate.py-upgrader ~/src/fooservice
 
-and then run it on a baseplate.py project you want to upgrade:
+You can also create a virtualenv and install it manually:
 
-    baseplate.py-upgrader ~/src/fooservice
+    python3.12 -m venv venv
+    venv/bin/pip install git+https://github.com/reddit/baseplate.py-upgrader
+    venv/bin/baseplate.py-upgrader ~/src/fooservice

--- a/baseplate_py_upgrader/__init__.py
+++ b/baseplate_py_upgrader/__init__.py
@@ -45,11 +45,12 @@ UPGRADES: Dict[str, str] = {
     "1.3": "1.4",
     "1.4": "1.5",
     "1.5": "2.0",
-    "2.0": "2.5",
-    "2.1": "2.5",
-    "2.2": "2.5",
-    "2.3": "2.5",
-    "2.4": "2.5",
+    "2.0": "2.6",
+    "2.1": "2.6",
+    "2.2": "2.6",
+    "2.3": "2.6",
+    "2.4": "2.6",
+    "2.5": "2.6",
 }
 
 # this is useful if we're dealing with pre-releases temporarily
@@ -75,6 +76,7 @@ UPDATERS: Dict[
     "2.3": no_op_upgrade,
     "2.4": no_op_upgrade,
     "2.5": no_op_upgrade,
+    "2.6": no_op_upgrade,
 }
 
 


### PR DESCRIPTION
This allows the upgrader to upgrade Baseplate repos to the newly-released 2.6.0 version.

I also updated the README to recommend using [pipx](https://github.com/pypa/pipx) for installing and running this tool inside an isolated virtualenv, or alternatively to install it inside a virtualenv manually. I don't think we should recommend doing `pip install X` with a global/user Python installation since this almost always causes problems later on.

I tested this on a service and can see it updates the baseplate version:
```
$ baseplate.py-upgrader .
Baseplate.py Upgrader
Upgrading .
Python version: 3.8
Current version: v2.3.3
Target version: v2.6.0 (2.6 series)

 ✓ Updated baseplate to 2.6.0 in requirements.txt

Automatic upgrade successful!
There's more to do:
 • Review the logs above.
 • Review the diff in your application.
 • Apply code formatters to clean up refactored code.
 • Thoroughly test your application.
 • Commit the changes.

$ git diff HEAD
diff --git a/requirements.txt b/requirements.txt
index ea2f28c..52cfa0e 100644
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==1.7.6
 PasteDeploy==2.0.1
 PyJWT==2.4.0
-baseplate==2.3.3
+baseplate==2.6.0
 certifi==2023.7.22
 chardet==3.0.4
 gevent==23.9.0

```